### PR TITLE
passing replication options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Creates a new SwarmNetworker that will open replication streams on the `corestor
 {
   id: crypto.randomBytes(32), // A randomly-generated peer ID,
   keyPair: HypercoreProtocol.keyPair(), // A NOISE keypair that's used across all connections.
+  onauthenticate: (remotePublicKey, cb) => { cb() }, // A NOISE keypair authentication hook
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ class CorestoreNetworker extends Nanoresource {
     this._replicationOpts = {
       encrypt: true,
       live: true,
-      keyPair: this.keyPair
+      keyPair: this.keyPair,
+      onauthenticate: opts.onauthenticate
     }
 
     this.streams = new Set()

--- a/test/all.js
+++ b/test/all.js
@@ -489,6 +489,25 @@ test('bidirectional extension send/receive', async t => {
   t.end()
 })
 
+test.only('onauthentication hook', async t => {
+  t.plan(2)
+  const { networker: networker1 } = await create({
+    onauthenticate (peerPublicKey, cb) {
+      t.deepEquals(peerPublicKey, networker2.keyPair.publicKey)
+      cb()
+    }
+  })
+  const { networker: networker2 } = await create()
+
+  const dkey = hypercoreCrypto.randomBytes(32)
+  await networker1.configure(dkey)
+  await networker2.configure(dkey)
+
+  await new Promise(resolve => setTimeout(resolve, 100))
+  await cleanup([networker1, networker2])
+  t.end()
+})
+
 async function create (opts = {}) {
   if (!bootstrap) {
     bootstrap = dht({


### PR DESCRIPTION
Using the corestore-networker removes a lot of stress from my setup but I try to authenticate the peers and that requires `keyPair` and `onauthenticate` option to work. In a test (this PR) I just added an optional `replicationOpts` key. This works fine for me and could work for others.

This is still a draft PR because I didn't add documentation & tests yet. Before I add these I am wondering:

Is it a good idea to add this option or should just keyPair & onauthenticate options added? Is the name `replicationOpts` okay?