### PR TITLE
Make hyperswarm optional, disable import in browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Creates a new SwarmNetworker that will open replication streams on the `corestor
   id: crypto.randomBytes(32), // A randomly-generated peer ID,
   keyPair: HypercoreProtocol.keyPair(), // A NOISE keypair that's used across all connections.
   onauthenticate: (remotePublicKey, cb) => { cb() }, // A NOISE keypair authentication hook
+  swarm: hyperswarm(), // A hyperswarm instance to use (e.g., hyperswarm-web in the browser)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ class CorestoreNetworker extends Nanoresource {
     this._streamsProcessing = 0
     this._streamsProcessed = 0
 
-    // Set in listen
-    this.swarm = null
+    // Passed in, or set in listen
+    this.swarm = opts.swarm || null
 
     this.setMaxListeners(0)
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "standard": "^12.0.1",
     "tape": "^4.9.0"
   },
+  "browser": {
+    "hyperswarm": false
+  },
   "scripts": {
     "test": "tape test/*.js"
   },


### PR DESCRIPTION
Closes #11 

This means that there won't be weird bundler errors with importing hyperswarm when packaging for browsers, and also enables people to pass in their own hyperswarm instance.

E.g. enables people to pass in hyperswarm-web instead of the default hyperswarm